### PR TITLE
Delete policy requests on completion

### DIFF
--- a/e2e/policies/slash-policies.test.ts
+++ b/e2e/policies/slash-policies.test.ts
@@ -122,6 +122,9 @@ describe('Policy Flows E2E', () => {
           m.subagentId === subagentId
       );
       expect(sanitize(actorNotif.content, reqId)).toBe(expectedActorContent);
+
+      const reqPath = path.resolve(env.e2eDir, `.clawmini/tmp/requests/${reqId}.json`);
+      expect(fs.existsSync(reqPath)).toBe(false);
     },
     15000
   );
@@ -153,7 +156,7 @@ describe('Policy Flows E2E', () => {
     expect(reply.content).toContain(`- ID: ${reqId} | Command: test-cmd`);
   }, 15000);
 
-  it('should persist a custom reason when /reject is given one', async () => {
+  it('should include a custom reason in /reject notifications and delete the request file', async () => {
     await env.addChat('chat-reject-reason');
     chat = await env.connect('chat-reject-reason');
 
@@ -183,8 +186,7 @@ describe('Policy Flows E2E', () => {
     expect(agentMsg.content).toContain('command looked suspicious');
 
     const reqPath = path.resolve(env.e2eDir, `.clawmini/tmp/requests/${reqId}.json`);
-    const stored = JSON.parse(fs.readFileSync(reqPath, 'utf8'));
-    expect(stored.rejectionReason).toBe('command looked suspicious');
+    expect(fs.existsSync(reqPath)).toBe(false);
   }, 15000);
 
   describe('validation branches', () => {
@@ -252,12 +254,13 @@ describe('Policy Flows E2E', () => {
 
       await env.sendMessage(`/approve ${reqId}`, { chat: 'chat-double-approve' });
 
+      // Approved requests are deleted, so the second /approve sees the request as gone.
       await chat.waitForMessage(
         (m): m is SystemMessage =>
           m.role === 'system' &&
           m.event === 'router' &&
           typeof m.content === 'string' &&
-          m.content.includes('Request is not pending')
+          m.content.includes(`Request not found: ${reqId}`)
       );
     }, 15000);
 

--- a/e2e/policies/startup-cleanup.test.ts
+++ b/e2e/policies/startup-cleanup.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { TestEnvironment } from '../_helpers/test-environment.js';
+import type { PolicyRequest, RequestState } from '../../src/shared/policies.js';
+
+describe('Policy Startup Cleanup E2E', () => {
+  let env: TestEnvironment;
+  let requestsDir: string;
+
+  const makeRequest = (id: string, state: RequestState): PolicyRequest => ({
+    id,
+    commandName: 'test-cmd',
+    args: [],
+    fileMappings: {},
+    state,
+    createdAt: Date.now(),
+    chatId: 'some-chat',
+    agentId: 'some-agent',
+  });
+
+  const writeRequest = (req: PolicyRequest) => {
+    fs.writeFileSync(path.join(requestsDir, `${req.id}.json`), JSON.stringify(req, null, 2));
+  };
+
+  beforeAll(async () => {
+    env = new TestEnvironment('e2e-upgrade-cleanup');
+    await env.setup();
+    await env.init();
+
+    requestsDir = path.resolve(env.e2eDir, '.clawmini/tmp/requests');
+    fs.mkdirSync(requestsDir, { recursive: true });
+
+    writeRequest(makeRequest('PENDING1', 'Pending'));
+    writeRequest(makeRequest('APPROVED1', 'Approved'));
+    writeRequest(makeRequest('REJECTED1', 'Rejected'));
+
+    await env.up();
+  }, 30000);
+
+  afterAll(() => env.teardown(), 30000);
+
+  it('deletes completed request files on startup and keeps pending ones', () => {
+    expect(fs.existsSync(path.join(requestsDir, 'PENDING1.json'))).toBe(true);
+    expect(fs.existsSync(path.join(requestsDir, 'APPROVED1.json'))).toBe(false);
+    expect(fs.existsSync(path.join(requestsDir, 'REJECTED1.json'))).toBe(false);
+  });
+});

--- a/src/daemon/api/agent-policy-endpoints.ts
+++ b/src/daemon/api/agent-policy-endpoints.ts
@@ -105,7 +105,6 @@ export const createPolicyRequest = apiProcedure
       );
 
       request.executionResult = { stdout, stderr, exitCode };
-      await store.save(request);
 
       const logMsg: PolicyRequestMessage = {
         id: randomUUID(),

--- a/src/daemon/api/policy-request.test.ts
+++ b/src/daemon/api/policy-request.test.ts
@@ -32,7 +32,7 @@ vi.mock('../policy-request-service.js', () => {
     PolicyRequestService: class {
       async createRequest() {
         return {
-          id: 'req-123',
+          id: 'REQ-123',
           commandName: 'test-cmd',
           args: ['arg1', 'arg2'],
           fileMappings: {
@@ -103,7 +103,7 @@ describe('createPolicyRequest preview message', () => {
       },
     });
 
-    expect(result.id).toBe('req-123');
+    expect(result.id).toBe('REQ-123');
 
     expect(chats.appendMessage).toHaveBeenCalledTimes(1);
     const callArgs = vi.mocked(chats.appendMessage).mock.calls[0]!;
@@ -116,14 +116,14 @@ describe('createPolicyRequest preview message', () => {
     // Assert preview content format
     const content = logMsg.content;
     expect(content).toContain('Sandbox Policy Request: test-cmd');
-    expect(content).toContain('ID: req-123');
+    expect(content).toContain('ID: REQ-123');
     expect(content).toContain('Args: arg1 arg2');
 
     expect(content).toContain('File [file1]:\n' + shortContent);
 
     // The long file should be truncated to 500 chars + suffix
     expect(content).toContain('File [file2]:\n' + 'A'.repeat(500) + '\n... (truncated)');
-    expect(content).toContain('Use /approve req-123 or /reject req-123 [reason]');
+    expect(content).toContain('Use /approve REQ-123 or /reject REQ-123 [reason]');
   });
 
   it('should create an auto-approved request and execute it immediately', async () => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -20,6 +20,7 @@ import { SettingsSchema } from '../shared/config.js';
 import { validateToken, getApiContext } from './auth.js';
 import path from 'node:path';
 import { exportLiteToEnvironment } from '../shared/lite.js';
+import { RequestStore } from './request-store.js';
 
 export async function initDaemon() {
   const socketPath = getSocketPath();
@@ -162,6 +163,15 @@ export async function initDaemon() {
     }
   };
   await cleanOrphanedSubagents();
+
+  try {
+    const removed = await new RequestStore(getWorkspaceRoot()).cleanupCompleted();
+    if (removed > 0) {
+      console.log(`Cleaned up ${removed} completed policy request file(s).`);
+    }
+  } catch (err) {
+    console.warn('Failed to clean completed policy requests:', err);
+  }
 
   await runHooks('up');
 

--- a/src/daemon/request-store.ts
+++ b/src/daemon/request-store.ts
@@ -47,6 +47,35 @@ export class RequestStore {
     await fs.writeFile(filePath, JSON.stringify(request, null, 2), 'utf8');
   }
 
+  async delete(id: string): Promise<void> {
+    const normalizedId = normalizePolicyId(id);
+    const filePath = this.getFilePath(normalizedId);
+    try {
+      await fs.unlink(filePath);
+    } catch (err: unknown) {
+      if (!isENOENT(err)) throw err;
+    }
+  }
+
+  async cleanupCompleted(): Promise<number> {
+    let removed = 0;
+    try {
+      const files = await fs.readdir(this.baseDir);
+      for (const file of files) {
+        if (!file.endsWith('.json')) continue;
+        const id = path.basename(file, '.json');
+        const req = await this.load(id);
+        if (req && req.state !== 'Pending') {
+          await this.delete(id);
+          removed++;
+        }
+      }
+    } catch (err: unknown) {
+      if (!isENOENT(err)) throw err;
+    }
+    return removed;
+  }
+
   async load(id: string): Promise<PolicyRequest | null> {
     const normalizedId = normalizePolicyId(id);
     const filePath = this.getFilePath(normalizedId);

--- a/src/daemon/routers/slash-policies.test.ts
+++ b/src/daemon/routers/slash-policies.test.ts
@@ -33,11 +33,13 @@ describe('slashPolicies', () => {
       list: vi.fn(),
       load: vi.fn(),
       save: vi.fn(),
+      delete: vi.fn(),
     };
     vi.mocked(RequestStore).mockImplementation(function (this: any) {
       this.list = mockStore.list;
       this.load = mockStore.load;
       this.save = mockStore.save;
+      this.delete = mockStore.delete;
       return this;
     } as any);
 
@@ -111,11 +113,8 @@ describe('slashPolicies', () => {
     const state = { message: '/approve req-1', messageId: 'mock-msg-id', chatId: 'chat-1' };
     const result = await slashPolicies(state);
 
-    expect(mockStore.save).toHaveBeenCalledWith({
-      ...pendingReq,
-      state: 'Approved',
-      executionResult: { stdout: 'hello world', stderr: '', exitCode: 0 },
-    });
+    expect(mockStore.save).not.toHaveBeenCalled();
+    expect(mockStore.delete).toHaveBeenCalledWith('req-1');
     expect(executeRequest).toHaveBeenCalledWith(pendingReq, expect.any(Object), undefined);
     expect(appendMessage).toHaveBeenCalledWith(
       'chat-1',
@@ -151,11 +150,8 @@ describe('slashPolicies', () => {
     };
     const result = await slashPolicies(state);
 
-    expect(mockStore.save).toHaveBeenCalledWith({
-      ...pendingReq,
-      state: 'Rejected',
-      rejectionReason: 'Not allowed',
-    });
+    expect(mockStore.save).not.toHaveBeenCalled();
+    expect(mockStore.delete).toHaveBeenCalledWith('req-1');
     expect(appendMessage).toHaveBeenCalledTimes(1);
     expect(appendMessage).toHaveBeenCalledWith(
       'chat-1',

--- a/src/daemon/routers/slash-policies.ts
+++ b/src/daemon/routers/slash-policies.ts
@@ -54,8 +54,6 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
       return { ...state, message: '', reply: `Policy not found: ${req.commandName}` };
     }
 
-    req.state = 'Approved';
-
     const workspaceRoot = getWorkspaceRoot();
     const hostCwd = await resolveRequestCwd(req.cwd, state.agentId, workspaceRoot);
 
@@ -68,8 +66,7 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
       state.agentId
     );
 
-    req.executionResult = { stdout, stderr, exitCode };
-    await store.save(req);
+    await store.delete(req.id);
 
     const agentMessage = `Request ${id} approved.\n\n${wrapInHtml('stdout', stdout)}\n\n${wrapInHtml('stderr', stderr)}\n\nExit Code: ${exitCode}`;
 
@@ -120,9 +117,7 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
     if (error) return error;
     if (!req || !store) return state; // Should not happen if error is undefined
 
-    req.state = 'Rejected';
-    req.rejectionReason = reason;
-    await store.save(req);
+    await store.delete(req.id);
 
     const agentMessage = `Request ${id} rejected. Reason: ${reason}`;
 


### PR DESCRIPTION
Policy requests are now deleted from disk when approved or rejected, instead of persisted with a terminal state. A daemon-startup sweep cleans up any stale completed files from prior versions or crashes.

- Drop the dead save() in the auto-approve path (nothing reads the persisted Approved record; lite.ts reads executionResult from the tRPC response).
- Remove dead mutations (req.state / req.executionResult / req.rejectionReason) immediately before delete() in the /approve and /reject handlers.
- Rename the new E2E from upgrade.test.ts to startup-cleanup.test.ts to match intent (sweep runs on every boot, not just upgrades).