### PR TITLE
Store sessionId on chat messages

### DIFF
--- a/e2e/cli/messages.test.ts
+++ b/e2e/cli/messages.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import path from 'node:path';
 import fs from 'node:fs';
-import { TestEnvironment, type ChatSubscription, commandMatching } from '../_helpers/test-environment.js';
+import {
+  TestEnvironment,
+  type ChatSubscription,
+  commandMatching,
+  type SystemMessage,
+  type ToolMessage,
+} from '../_helpers/test-environment.js';
 
 describe('E2E Messages Tests', () => {
   let env: TestEnvironment;
@@ -252,4 +258,65 @@ describe('E2E Messages Tests', () => {
     expect(log3.stderr).toContain('ERR APPEND');
     expect(log3.stderr).toContain('getMessageContent failed: EXTRACTION_FAIL');
   }, 15000);
+});
+
+describe('E2E Messages sessionId Persistence', () => {
+  let env: TestEnvironment;
+  let chat: ChatSubscription | undefined;
+
+  beforeAll(async () => {
+    env = new TestEnvironment('e2e-tmp-msg-sid');
+    await env.setup();
+    await env.setupSubagentEnv();
+    await env.getAgentCredentials();
+  }, 30000);
+
+  afterAll(() => env.teardown(), 30000);
+  afterEach(() => env.disconnectAll());
+
+  it('stamps sessionId on user, command, agent, tool, and cron system messages', async () => {
+    chat = await env.connect('__creds__');
+
+    await env.sendMessage('echo hello-session', {
+      chat: '__creds__',
+      agent: 'debug-agent',
+    });
+
+    const userMsg = await chat.waitForMessage(
+      (m) => m.role === 'user' && m.content === 'echo hello-session'
+    );
+    const cmdMsg = await chat.waitForMessage(
+      commandMatching((m) => m.stdout.includes('echo hello-session'))
+    );
+    const replyMsg = await chat.waitForMessage((m) => m.role === 'agent');
+
+    expect(userMsg.sessionId).toBeTruthy();
+    expect(cmdMsg.sessionId).toBe(userMsg.sessionId);
+    expect(replyMsg.sessionId).toBe(userMsg.sessionId);
+
+    await env.runLite(['tool', 'session-tool', JSON.stringify({ probe: 1 })]);
+    const toolMsg = await chat.waitForMessage(
+      (m): m is ToolMessage => m.role === 'tool' && m.name === 'session-tool'
+    );
+    expect(toolMsg.sessionId).toBe(userMsg.sessionId);
+
+    await env.runLite([
+      'jobs', 'add', 'session-id-cron',
+      '--at', '1s',
+      '--message', 'echo session-cron-fired',
+      '--session', 'new',
+    ]);
+    const sysMsg = await chat.waitForMessage(
+      (m): m is SystemMessage =>
+        m.role === 'system' && (m as SystemMessage).event === 'cron',
+      10000
+    );
+    expect(sysMsg.sessionId).toBeTruthy();
+
+    const cronCmd = await chat.waitForMessage(
+      commandMatching((m) => m.stdout.includes('echo session-cron-fired')),
+      10000
+    );
+    expect(cronCmd.sessionId).toBe(sysMsg.sessionId);
+  }, 45000);
 });

--- a/e2e/cli/messages.test.ts
+++ b/e2e/cli/messages.test.ts
@@ -258,6 +258,47 @@ describe('E2E Messages Tests', () => {
     expect(log3.stderr).toContain('ERR APPEND');
     expect(log3.stderr).toContain('getMessageContent failed: EXTRACTION_FAIL');
   }, 15000);
+
+  it('should tail legacy chat entries that predate the sessionId field', async () => {
+    await env.addChat('legacy-chat', 'default');
+
+    const ts = new Date().toISOString();
+    const legacyLines = [
+      { id: 'u1', role: 'user', content: 'legacy user message', timestamp: ts },
+      {
+        id: 'c1',
+        role: 'command',
+        content: 'legacy cmd output',
+        messageId: 'u1',
+        command: 'echo legacy',
+        cwd: '/tmp',
+        stdout: 'legacy',
+        stderr: '',
+        exitCode: 0,
+        timestamp: ts,
+      },
+      { id: 'a1', role: 'agent', content: 'legacy agent reply', timestamp: ts },
+    ];
+    const chatFile = env.getChatPath('legacy-chat', 'chat.jsonl');
+    fs.writeFileSync(chatFile, legacyLines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+
+    const { stdout, code } = await env.runCli(['messages', 'tail', '--chat', 'legacy-chat']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('legacy user message');
+    expect(stdout).toContain('legacy agent reply');
+
+    const { stdout: jsonStdout, code: jsonCode } = await env.runCli([
+      'messages',
+      'tail',
+      '--json',
+      '--chat',
+      'legacy-chat',
+    ]);
+    expect(jsonCode).toBe(0);
+    expect(jsonStdout).toContain('"content":"legacy user message"');
+    expect(jsonStdout).toContain('"content":"legacy cmd output"');
+    expect(jsonStdout).toContain('"content":"legacy agent reply"');
+  });
 });
 
 describe('E2E Messages sessionId Persistence', () => {

--- a/src/daemon/agent/agent-session.ts
+++ b/src/daemon/agent/agent-session.ts
@@ -46,7 +46,7 @@ export class AgentSession {
     this.workspaceRoot = config.workspaceRoot;
     this.globalSettings = config.globalSettings;
 
-    this.logger = config.logger ?? createChatLogger(this.chatId, this.subagentId);
+    this.logger = config.logger ?? createChatLogger(this.chatId, this.subagentId, this.sessionId);
   }
 
   async buildExecutionContext(

--- a/src/daemon/agent/chat-logger.test.ts
+++ b/src/daemon/agent/chat-logger.test.ts
@@ -38,11 +38,52 @@ describe('ChatLogger', () => {
       );
     });
 
+    it('should inject sessionId into outgoing messages', async () => {
+      const logger = createChatLogger('chat-1', undefined, 'session-42');
+      await logger.logUserMessage('hello session');
+      await logger.logAgentReply({ content: 'reply' });
+      await logger.logCommandResult({
+        messageId: 'm',
+        content: '',
+        command: 'echo',
+        cwd: '/tmp',
+        result: { stdout: '', stderr: '', exitCode: 0 },
+      });
+      await logger.logToolMessage({
+        content: 'c',
+        messageId: 'm',
+        name: 't',
+        payload: {},
+      });
+      await logger.logSystemMessage({ content: 's', event: 'cron' });
+
+      const calls = vi.mocked(daemonChats.appendMessage).mock.calls;
+      expect(calls).toHaveLength(5);
+      for (const [, msg] of calls) {
+        expect(msg).toEqual(expect.objectContaining({ sessionId: 'session-42' }));
+        expect(msg).not.toHaveProperty('subagentId');
+      }
+    });
+
     it('should filter incoming logs for the subagent', async () => {
       const mockMessages: ChatMessage[] = [
-        { id: '1', role: 'user', content: 'root msg', timestamp: '1' },
-        { id: '2', role: 'user', content: 'sub msg', timestamp: '2', subagentId: 'sub-1' },
-        { id: '3', role: 'user', content: 'other sub', timestamp: '3', subagentId: 'sub-2' },
+        { id: '1', role: 'user', content: 'root msg', timestamp: '1', sessionId: undefined },
+        {
+          id: '2',
+          role: 'user',
+          content: 'sub msg',
+          timestamp: '2',
+          subagentId: 'sub-1',
+          sessionId: undefined,
+        },
+        {
+          id: '3',
+          role: 'user',
+          content: 'other sub',
+          timestamp: '3',
+          subagentId: 'sub-2',
+          sessionId: undefined,
+        },
       ];
       vi.mocked(daemonChats.getMessages).mockResolvedValue(mockMessages);
 
@@ -56,10 +97,31 @@ describe('ChatLogger', () => {
 
     it('should limit messages after filtering', async () => {
       const mockMessages: ChatMessage[] = [
-        { id: '1', role: 'user', content: 'root msg', timestamp: '1' },
-        { id: '2', role: 'user', content: 'sub msg 1', timestamp: '2', subagentId: 'sub-1' },
-        { id: '3', role: 'user', content: 'other sub', timestamp: '3', subagentId: 'sub-2' },
-        { id: '4', role: 'user', content: 'sub msg 2', timestamp: '4', subagentId: 'sub-1' },
+        { id: '1', role: 'user', content: 'root msg', timestamp: '1', sessionId: undefined },
+        {
+          id: '2',
+          role: 'user',
+          content: 'sub msg 1',
+          timestamp: '2',
+          subagentId: 'sub-1',
+          sessionId: undefined,
+        },
+        {
+          id: '3',
+          role: 'user',
+          content: 'other sub',
+          timestamp: '3',
+          subagentId: 'sub-2',
+          sessionId: undefined,
+        },
+        {
+          id: '4',
+          role: 'user',
+          content: 'sub msg 2',
+          timestamp: '4',
+          subagentId: 'sub-1',
+          sessionId: undefined,
+        },
       ];
       vi.mocked(daemonChats.getMessages).mockResolvedValue(mockMessages);
 
@@ -72,8 +134,15 @@ describe('ChatLogger', () => {
 
     it('should not return subagent messages if no subagentId', async () => {
       const mockMessages: ChatMessage[] = [
-        { id: '1', role: 'user', content: 'root msg', timestamp: '1' },
-        { id: '2', role: 'user', content: 'sub msg 1', timestamp: '2', subagentId: 'sub-1' },
+        { id: '1', role: 'user', content: 'root msg', timestamp: '1', sessionId: undefined },
+        {
+          id: '2',
+          role: 'user',
+          content: 'sub msg 1',
+          timestamp: '2',
+          subagentId: 'sub-1',
+          sessionId: undefined,
+        },
       ];
       vi.mocked(daemonChats.getMessages).mockResolvedValue(mockMessages);
 

--- a/src/daemon/agent/chat-logger.ts
+++ b/src/daemon/agent/chat-logger.ts
@@ -13,11 +13,12 @@ import {
 } from '../chats.js';
 import type { Logger } from './types.js';
 
-export function createChatLogger(chatId: string, subagentId?: string): Logger {
+export function createChatLogger(chatId: string, subagentId?: string, sessionId?: string): Logger {
   async function append<T extends ChatMessage>(msg: T): Promise<T> {
-    const finalMsg = subagentId ? { ...msg, subagentId } : msg;
+    let finalMsg: T = msg;
+    if (subagentId) finalMsg = { ...finalMsg, subagentId };
     await appendMessage(chatId, finalMsg);
-    return finalMsg as T;
+    return finalMsg;
   }
 
   return {
@@ -45,6 +46,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         role: 'user',
         content: msg,
         timestamp: new Date().toISOString(),
+        sessionId,
       } satisfies UserMessage),
 
     logCommandResult: async ({ messageId, content, command, cwd, result }) =>
@@ -53,6 +55,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         role: 'command',
         content,
         timestamp: new Date().toISOString(),
+        sessionId,
 
         messageId,
 
@@ -61,7 +64,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         stdout: result.stdout,
         stderr: result.stderr,
         exitCode: result.exitCode,
-      }),
+      } satisfies CommandLogMessage),
 
     logSystemEvent: async ({ content }) =>
       append({
@@ -69,6 +72,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         role: 'command',
         content,
         timestamp: new Date().toISOString(),
+        sessionId,
 
         messageId: crypto.randomUUID(),
 
@@ -85,6 +89,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         role: 'system',
         content,
         timestamp: new Date().toISOString(),
+        sessionId,
 
         messageId,
         event: 'router',
@@ -97,6 +102,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         role: 'command',
         content,
         timestamp: new Date().toISOString(),
+        sessionId,
 
         messageId,
 
@@ -115,6 +121,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         content,
         event,
         timestamp: new Date().toISOString(),
+        sessionId,
       };
       if (messageId !== undefined) {
         msg.messageId = messageId;
@@ -133,6 +140,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         subagentId: targetSubagentId,
         status,
         timestamp: new Date().toISOString(),
+        sessionId,
       };
       return append<SubagentStatusMessage>(msg);
     },
@@ -143,6 +151,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         role: 'agent',
         content,
         timestamp: new Date().toISOString(),
+        sessionId,
       };
       if (files !== undefined) {
         msg.files = files;
@@ -159,6 +168,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         name,
         payload,
         timestamp: new Date().toISOString(),
+        sessionId,
       };
       return append<ToolMessage>(msg);
     },
@@ -181,6 +191,7 @@ export function createChatLogger(chatId: string, subagentId?: string): Logger {
         args,
         status,
         timestamp: new Date().toISOString(),
+        sessionId,
       };
       return append<PolicyRequestMessage>(msg);
     },

--- a/src/daemon/api/agent-policy-endpoints.ts
+++ b/src/daemon/api/agent-policy-endpoints.ts
@@ -117,6 +117,7 @@ export const createPolicyRequest = apiProcedure
         status: 'approved',
         content: `[Auto-approved] Policy ${input.commandName} was executed.\n\nCommand: ${commandStr}\nExit Code: ${exitCode}\n\nStdout:\n${stdout}\n\nStderr:\n${stderr}`,
         timestamp: new Date().toISOString(),
+        sessionId: ctx.tokenPayload.sessionId,
         ...(ctx.tokenPayload.subagentId ? { subagentId: ctx.tokenPayload.subagentId } : {}),
       };
 
@@ -138,6 +139,7 @@ export const createPolicyRequest = apiProcedure
       content: previewContent,
       timestamp: new Date().toISOString(),
       displayRole: 'agent',
+      sessionId: ctx.tokenPayload.sessionId,
     };
 
     await appendMessage(chatId, logMsg);

--- a/src/daemon/api/agent-router.ts
+++ b/src/daemon/api/agent-router.ts
@@ -57,6 +57,7 @@ export const logMessage = apiProcedure
       command: `clawmini-lite log${filesArgStr}`,
       cwd: process.cwd(),
       exitCode: 0,
+      sessionId: ctx.tokenPayload.sessionId,
       ...(ctx.tokenPayload.subagentId ? { subagentId: ctx.tokenPayload.subagentId } : {}),
       ...(filePaths.length > 0 ? { files: filePaths } : {}),
     };
@@ -94,6 +95,7 @@ export const logReplyMessage = apiProcedure
       role: 'agent',
       content: input.message,
       timestamp,
+      sessionId: ctx.tokenPayload.sessionId,
       ...(ctx.tokenPayload.subagentId ? { subagentId: ctx.tokenPayload.subagentId } : {}),
       ...(filePaths.length > 0 ? { files: filePaths } : {}),
     };
@@ -136,6 +138,7 @@ export const logToolMessage = apiProcedure
       payload: payloadObj,
       content: contentStr,
       timestamp,
+      sessionId: ctx.tokenPayload.sessionId,
       ...(ctx.tokenPayload.subagentId ? { subagentId: ctx.tokenPayload.subagentId } : {}),
     };
 

--- a/src/daemon/api/subagent-utils.ts
+++ b/src/daemon/api/subagent-utils.ts
@@ -75,7 +75,7 @@ export async function executeSubagent(
       return finalSettings;
     });
 
-    const logger = createChatLogger(chatId, subagentId);
+    const logger = createChatLogger(chatId, subagentId, sessionId);
 
     // Emit debug message to wake up waiters
     await logger.logSubagentStatus({ subagentId, status: 'completed' });
@@ -125,7 +125,7 @@ export async function executeSubagent(
       }
       return errSettings;
     });
-    const logger = createChatLogger(chatId, subagentId);
+    const logger = createChatLogger(chatId, subagentId, sessionId);
     await logger.logSubagentStatus({ subagentId, status: 'failed' });
   }
 }

--- a/src/daemon/message.ts
+++ b/src/daemon/message.ts
@@ -27,7 +27,7 @@ export async function executeDirectMessage(
     | 'other',
   displayRole?: 'user' | 'agent'
 ) {
-  const logger = createChatLogger(chatId, subagentId);
+  const logger = createChatLogger(chatId, subagentId, state.sessionId);
 
   let msgId: string;
   if (systemEvent) {

--- a/src/daemon/routers/slash-policies.ts
+++ b/src/daemon/routers/slash-policies.ts
@@ -79,6 +79,7 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
       content: `Request ${id} (\`${req.commandName}\`) approved.`,
       timestamp: new Date().toISOString(),
       // Explicitly omitted subagentId to show in main chat
+      sessionId: state.sessionId,
     };
 
     await appendMessage(state.chatId, userNotificationMsg);
@@ -130,6 +131,7 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
       content: `Request ${id} (\`${req.commandName}\`) rejected. Reason: ${reason}`,
       timestamp: new Date().toISOString(),
       // Explicitly omitted subagentId to show in main chat
+      sessionId: state.sessionId,
     };
 
     await appendMessage(state.chatId, userNotificationMsg);

--- a/src/shared/adapters/filtering.test.ts
+++ b/src/shared/adapters/filtering.test.ts
@@ -12,17 +12,30 @@ describe('shouldDisplayMessage', () => {
       content: 'hello',
       subagentId: 'sub1',
       timestamp: '',
+      sessionId: undefined,
     };
     expect(shouldDisplayMessage(msg, defaultConfig)).toBe(false);
   });
 
   it('hides standard user messages without subagentId', () => {
-    const msg: ChatMessage = { id: '1', role: 'user', content: 'hello', timestamp: '' };
+    const msg: ChatMessage = {
+      id: '1',
+      role: 'user',
+      content: 'hello',
+      timestamp: '',
+      sessionId: undefined,
+    };
     expect(shouldDisplayMessage(msg, defaultConfig)).toBe(false);
   });
 
   it('displays standard agent messages without subagentId', () => {
-    const msg: ChatMessage = { id: '1', role: 'agent', content: 'hello', timestamp: '' };
+    const msg: ChatMessage = {
+      id: '1',
+      role: 'agent',
+      content: 'hello',
+      timestamp: '',
+      sessionId: undefined,
+    };
     expect(shouldDisplayMessage(msg, defaultConfig)).toBe(true);
   });
 
@@ -38,6 +51,7 @@ describe('shouldDisplayMessage', () => {
       stderr: '',
       exitCode: 0,
       timestamp: '',
+      sessionId: undefined,
     };
     expect(shouldDisplayMessage(msg, defaultConfig)).toBe(false);
   });
@@ -49,6 +63,7 @@ describe('shouldDisplayMessage', () => {
       content: 'hello',
       subagentId: 'sub1',
       timestamp: '',
+      sessionId: undefined,
     };
     expect(shouldDisplayMessage(msg, { filters: { subagent: true } })).toBe(true);
   });
@@ -60,6 +75,7 @@ describe('shouldDisplayMessage', () => {
       content: 'hello subagent',
       subagentId: 'sub1',
       timestamp: '',
+      sessionId: undefined,
     };
     expect(shouldDisplayMessage(msg, { filters: { subagent: true } })).toBe(true);
   });
@@ -76,6 +92,7 @@ describe('shouldDisplayMessage', () => {
       stderr: '',
       exitCode: 0,
       timestamp: '',
+      sessionId: undefined,
     };
     expect(shouldDisplayMessage(msg, { filters: { command: true } })).toBe(true);
   });
@@ -83,7 +100,13 @@ describe('shouldDisplayMessage', () => {
 
 describe('formatMessage', () => {
   it('returns content as-is for messages without subagentId', () => {
-    const msg: ChatMessage = { id: '1', role: 'agent', content: 'hello world', timestamp: '' };
+    const msg: ChatMessage = {
+      id: '1',
+      role: 'agent',
+      content: 'hello world',
+      timestamp: '',
+      sessionId: undefined,
+    };
     expect(formatMessage(msg)).toBe('hello world');
   });
 
@@ -94,6 +117,7 @@ describe('formatMessage', () => {
       content: 'do task',
       subagentId: 'sub1',
       timestamp: '',
+      sessionId: undefined,
     };
     expect(formatMessage(msg)).toBe('[To:sub1]\ndo task');
   });
@@ -105,6 +129,7 @@ describe('formatMessage', () => {
       content: 'done',
       subagentId: 'sub1',
       timestamp: '',
+      sessionId: undefined,
     };
     expect(formatMessage(msg)).toBe('[From:sub1]\ndone');
   });

--- a/src/shared/chats.test.ts
+++ b/src/shared/chats.test.ts
@@ -58,6 +58,7 @@ describe('chats utilities', () => {
       role: 'user',
       content: 'Hello',
       timestamp: new Date().toISOString(),
+      sessionId: undefined,
     };
 
     const msg2: CommandLogMessage = {
@@ -71,6 +72,7 @@ describe('chats utilities', () => {
       command: 'echo output',
       cwd: '/tmp',
       exitCode: 0,
+      sessionId: undefined,
     };
 
     const msg3: CommandLogMessage = {
@@ -84,6 +86,7 @@ describe('chats utilities', () => {
       command: 'router',
       cwd: '/tmp',
       exitCode: 0,
+      sessionId: undefined,
     };
 
     await appendMessage('chat1', msg1, TEST_DIR);
@@ -129,6 +132,7 @@ describe('chats utilities', () => {
       role: 'user',
       content: `Message ${i + 1}`,
       timestamp: new Date().toISOString(),
+      sessionId: undefined,
     }));
 
     for (const msg of msgs) {

--- a/src/shared/chats.ts
+++ b/src/shared/chats.ts
@@ -14,6 +14,7 @@ export interface BaseMessage {
   content: string;
   timestamp: string;
   subagentId?: string;
+  sessionId: string | undefined;
 }
 
 export interface UserMessage extends BaseMessage {


### PR DESCRIPTION
Adds required sessionId to BaseMessage (string | undefined, so older logs still parse) and threads it through every construction site: the chat logger factory, direct appendMessage calls in the agent/policy APIs, and slash-policy notifications. Making the field required forces the compiler to flag any missed site so sessionId can't be silently dropped.