### PR TITLE
Gate propose-policy allowHelp/autoApprove behind --dangerously- flags

### DIFF
--- a/e2e/policies/propose-policy.test.ts
+++ b/e2e/policies/propose-policy.test.ts
@@ -73,7 +73,70 @@ describe('propose-policy CLI', () => {
     expect(policies.policies['echo-test'].description).toBe('A simple echo command');
     expect(policies.policies['echo-test'].command).toBe('echo');
     expect(policies.policies['echo-test'].args).toEqual(['"Hello', 'World"']);
-    expect(policies.policies['echo-test'].allowHelp).toBe(true);
+    // Defaults: both dangerous opt-ins are off.
+    expect(policies.policies['echo-test'].allowHelp).toBe(false);
+    expect(policies.policies['echo-test'].autoApprove).toBe(false);
+  });
+
+  it('should set autoApprove and allowHelp when dangerous flags are passed', async () => {
+    const { stdout, stderr, code } = await env.runBin(binPath, [
+      '--name',
+      'dangerous-echo',
+      '--description',
+      'Echo with both dangerous opt-ins',
+      '--command',
+      'echo dangerous',
+      '--dangerously-auto-approve',
+      '--dangerously-allow-help',
+    ]);
+
+    if (code !== 0) console.error(stderr);
+    expect(code).toBe(0);
+    expect(stdout).toContain("Successfully proposed and registered policy 'dangerous-echo'");
+
+    const policiesPath = path.resolve(env.e2eDir, '.clawmini/policies.json');
+    const policies = JSON.parse(fs.readFileSync(policiesPath, 'utf8'));
+
+    expect(policies.policies['dangerous-echo'].allowHelp).toBe(true);
+    expect(policies.policies['dangerous-echo'].autoApprove).toBe(true);
+  });
+
+  it('should set only autoApprove when only --dangerously-auto-approve is passed', async () => {
+    const { code } = await env.runBin(binPath, [
+      '--name',
+      'auto-only',
+      '--description',
+      'Auto-approve only',
+      '--command',
+      'echo auto',
+      '--dangerously-auto-approve',
+    ]);
+    expect(code).toBe(0);
+
+    const policiesPath = path.resolve(env.e2eDir, '.clawmini/policies.json');
+    const policies = JSON.parse(fs.readFileSync(policiesPath, 'utf8'));
+
+    expect(policies.policies['auto-only'].autoApprove).toBe(true);
+    expect(policies.policies['auto-only'].allowHelp).toBe(false);
+  });
+
+  it('should set only allowHelp when only --dangerously-allow-help is passed', async () => {
+    const { code } = await env.runBin(binPath, [
+      '--name',
+      'help-only',
+      '--description',
+      'Allow help only',
+      '--command',
+      'echo help',
+      '--dangerously-allow-help',
+    ]);
+    expect(code).toBe(0);
+
+    const policiesPath = path.resolve(env.e2eDir, '.clawmini/policies.json');
+    const policies = JSON.parse(fs.readFileSync(policiesPath, 'utf8'));
+
+    expect(policies.policies['help-only'].allowHelp).toBe(true);
+    expect(policies.policies['help-only'].autoApprove).toBe(false);
   });
 
   it('should create a policy with a script file', async () => {

--- a/src/cli/propose-policy.ts
+++ b/src/cli/propose-policy.ts
@@ -14,6 +14,16 @@ proposePolicyCmd
   .requiredOption('--description <description>', 'Description of the policy')
   .option('--command <command_string>', 'The shell command to run (e.g. "npm install -g")')
   .option('--script-file <path>', 'Path to a script file (mapped securely via --file)')
+  .option(
+    '--dangerously-auto-approve',
+    'Skip user approval for every invocation of this policy. Only safe for fully sandboxed, side-effect-free commands.',
+    false
+  )
+  .option(
+    '--dangerously-allow-help',
+    'Allow the agent to run the policy with `--help` without approval. Only safe if the underlying command treats `--help` as read-only.',
+    false
+  )
   .addHelpText(
     'after',
     `
@@ -24,6 +34,9 @@ Examples:
   2. Propose a policy using a custom script file:
      # First, write your script to a file (e.g., install.sh)
      clawmini-lite request propose-policy --file script=./install.sh -- --name custom-install --description "Run custom install script" --script-file "{{script}}"
+
+  3. Propose a policy that auto-approves and allows --help discovery:
+     clawmini-lite request propose-policy -- --name list-files --description "List files" --command "ls" --dangerously-auto-approve --dangerously-allow-help
 `
   )
   .action((options) => {
@@ -31,6 +44,8 @@ Examples:
     const description = options.description;
     const commandStr = options.command;
     const scriptFile = options.scriptFile;
+    const autoApprove = !!options.dangerouslyAutoApprove;
+    const allowHelp = !!options.dangerouslyAllowHelp;
 
     if (!/^[a-z0-9-]+$/.test(name)) {
       console.error(
@@ -59,7 +74,8 @@ Examples:
 
     const policyDefinition: PolicyDefinition = {
       description,
-      allowHelp: true,
+      allowHelp,
+      autoApprove,
       command: '',
     };
 

--- a/templates/skills/clawmini-requests/SKILL.md
+++ b/templates/skills/clawmini-requests/SKILL.md
@@ -69,9 +69,16 @@ If you need to perform an action that isn't covered by an existing policy, you c
 
 You must provide a `--name` and `--description`, and either a shell `--command` or a `--script-file`.
 
+By default a proposed policy is **safe**: every invocation requires the user to approve it, and `--help` requests are blocked. You can opt in to looser behavior with two flags — both are prefixed `--dangerously-` because the user only sees them at proposal time:
+
+- `--dangerously-auto-approve`: future invocations of this policy run without the user reviewing each request. Only use for fully sandboxed, side-effect-free commands (e.g. read-only listings of local files). Never use for anything that mutates state, talks to the network, or spends money.
+- `--dangerously-allow-help`: lets you (the agent) run `<policy> --help` without approval. Safe only if the underlying command actually treats `--help` as read-only — many CLIs do, but custom scripts may not.
+
+If neither flag is set, both default to `false`. Prefer the safe default; only request the dangerous flags when you can justify them in the policy description.
+
 **Examples:**
 
-1. **Propose a simple command wrapper:**
+1. **Propose a simple command wrapper (safe defaults):**
 
    ```bash
    clawmini-lite.js request propose-policy -- --name npm-install --description "Run npm install globally" --command "npm install -g"
@@ -81,6 +88,12 @@ You must provide a `--name` and `--description`, and either a shell `--command` 
    First, write your complex logic to a file (e.g., `./script.sh`). **Note: The script file path MUST be inside your allowed workspace directory or use relative paths.**
    ```bash
    clawmini-lite.js request propose-policy --file script=./script.sh -- --name custom-action --description "Run a custom deployment script" --script-file "{{script}}"
+   ```
+
+3. **Propose a read-only policy that auto-approves and exposes `--help`:**
+
+   ```bash
+   clawmini-lite.js request propose-policy -- --name list-files --description "List files in the workspace (read-only)" --command "ls" --dangerously-auto-approve --dangerously-allow-help
    ```
 
 ## Creating New Skills for Policies


### PR DESCRIPTION
Proposed policies now default to requiring approval for every invocation and blocking --help, so the safe default no longer depends on the agent remembering to opt out. Callers opt in explicitly via --dangerously-auto-approve and --dangerously-allow-help, which makes the risk visible at proposal time.

Fixes #152
Fixes #174