### PR TITLE
Fix Google Chat workspace events subscription lifecycle

### DIFF
--- a/e2e/adapters/adapter-google-chat-inbound.test.ts
+++ b/e2e/adapters/adapter-google-chat-inbound.test.ts
@@ -291,7 +291,11 @@ describe('Google Chat Adapter E2E — inbound (Pub/Sub → daemon)', () => {
 
     const fetchMock = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
       new Response(
-        JSON.stringify({ name: 'subscriptions/abc', expireTime: '2026-01-01T00:00:00Z' }),
+        JSON.stringify({
+          name: 'operations/abc',
+          done: true,
+          response: { name: 'subscriptions/abc', expireTime: '2026-01-01T00:00:00Z' },
+        }),
         { status: 200 }
       )
     );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,5 +55,11 @@ export default defineConfig([
       'no-restricted-syntax': 'off',
     },
   },
+  {
+    files: ['scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
   eslintConfigPrettier,
 ]);

--- a/scripts/check-gchat-subscription.mjs
+++ b/scripts/check-gchat-subscription.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Usage:
+//   node /path/to/check-gchat-subscription.mjs                    # LIST
+//   node /path/to/check-gchat-subscription.mjs <channelKey>       # LIST + state entry + GET stored id
+//   node /path/to/check-gchat-subscription.mjs --get <resource>   # GET arbitrary resource
+//     e.g. --get subscriptions/chat-spaces-czpBQVFB...
+//          --get operations/ClgK...
+//
+// Run from the directory containing state.json + config.json
+// (typically .clawmini/adapters/google-chat/).
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const getIdx = args.indexOf('--get');
+const explicitGet = getIdx >= 0 ? args[getIdx + 1] : null;
+const channelKey = getIdx >= 0 ? null : args[0];
+const cwd = process.cwd();
+
+const [stateRaw, configRaw] = await Promise.all([
+  fs.readFile(path.join(cwd, 'state.json'), 'utf-8'),
+  fs.readFile(path.join(cwd, 'config.json'), 'utf-8'),
+]);
+const state = JSON.parse(stateRaw);
+const config = JSON.parse(configRaw);
+
+const refreshToken = state.oauthTokens?.refresh_token;
+if (!refreshToken) {
+  console.error('No refresh_token in state.oauthTokens. Cannot mint access token.');
+  process.exit(1);
+}
+if (!config.oauthClientId || !config.oauthClientSecret) {
+  console.error('Missing oauthClientId/oauthClientSecret in config.json.');
+  process.exit(1);
+}
+
+console.log('--- Refreshing access token ---');
+const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  body: new URLSearchParams({
+    client_id: config.oauthClientId,
+    client_secret: config.oauthClientSecret,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  }).toString(),
+});
+if (!tokenRes.ok) {
+  console.error(`Token refresh failed: HTTP ${tokenRes.status}`);
+  console.error(await tokenRes.text());
+  process.exit(1);
+}
+const { access_token: accessToken } = await tokenRes.json();
+console.log('OK');
+
+async function getJson(url) {
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  const body = await res.text();
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    parsed = body;
+  }
+  return { status: res.status, body: parsed };
+}
+
+console.log('\n--- LIST https://workspaceevents.googleapis.com/v1/subscriptions ---');
+// The List endpoint requires a filter scoped to one Workspace app's event
+// types. Restrict to chat message-created events.
+const listFilter = 'event_types:"google.workspace.chat.message.v1.created"';
+const listUrl =
+  'https://workspaceevents.googleapis.com/v1/subscriptions?filter=' +
+  encodeURIComponent(listFilter);
+const listed = await getJson(listUrl);
+console.log(`HTTP ${listed.status}`);
+console.log(JSON.stringify(listed.body, null, 2));
+
+if (explicitGet) {
+  console.log(`\n--- GET https://workspaceevents.googleapis.com/v1/${explicitGet} ---`);
+  const r = await getJson(`https://workspaceevents.googleapis.com/v1/${explicitGet}`);
+  console.log(`HTTP ${r.status}`);
+  console.log(JSON.stringify(r.body, null, 2));
+}
+
+if (channelKey) {
+  console.log(`\n--- State entry for ${channelKey} ---`);
+  const entry = state.channelChatMap?.[channelKey];
+  if (!entry) {
+    const keys = Object.keys(state.channelChatMap ?? {});
+    console.error(`No entry. Available keys (${keys.length}): ${keys.join(', ') || '<none>'}`);
+  } else {
+    console.log(JSON.stringify(entry, null, 2));
+    if (entry.subscriptionId) {
+      console.log(
+        `\n--- GET https://workspaceevents.googleapis.com/v1/${entry.subscriptionId} ---`
+      );
+      const r = await getJson(`https://workspaceevents.googleapis.com/v1/${entry.subscriptionId}`);
+      console.log(`HTTP ${r.status}`);
+      console.log(JSON.stringify(r.body, null, 2));
+    }
+  }
+}

--- a/src/adapter-google-chat/client.test.ts
+++ b/src/adapter-google-chat/client.test.ts
@@ -186,11 +186,15 @@ describe('Google Chat Adapter Client', () => {
         (c: unknown[]) => c[0] === 'message'
       )![1] as (msg: unknown) => Promise<void>;
 
+      // Workspace Events create returns an LRO, which we now poll. Mock a
+      // done=true operation whose `response` carries the real subscription.
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
-        json: vi
-          .fn()
-          .mockResolvedValue({ name: 'subscriptions/123', expireTime: '2026-01-01T00:00:00Z' }),
+        json: vi.fn().mockResolvedValue({
+          name: 'operations/abc',
+          done: true,
+          response: { name: 'subscriptions/123', expireTime: '2026-01-01T00:00:00Z' },
+        }),
       });
       globalThis.fetch = mockFetch;
 

--- a/src/adapter-google-chat/cron.test.ts
+++ b/src/adapter-google-chat/cron.test.ts
@@ -1,14 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renewExpiringSubscriptions, startSubscriptionRenewalCron } from './cron.js';
 import * as stateApi from './state.js';
-import * as authApi from './auth.js';
+import * as subscriptionsApi from './subscriptions.js';
 import type { GoogleChatState } from './state.js';
 import type { GoogleChatConfig } from './config.js';
-import type { OAuth2Client } from 'google-auth-library';
 
-// Mock dependencies
 vi.mock('./state.js');
-vi.mock('./auth.js');
+vi.mock('./subscriptions.js');
 
 describe('Subscription Renewal Cron', () => {
   const mockConfig: GoogleChatConfig = {
@@ -26,9 +24,6 @@ describe('Subscription Renewal Cron', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.useFakeTimers();
-
-    // Reset global fetch mock
-    global.fetch = vi.fn();
   });
 
   afterEach(() => {
@@ -52,11 +47,10 @@ describe('Subscription Renewal Cron', () => {
 
     await renewExpiringSubscriptions(mockConfig);
 
-    expect(authApi.getUserAuthClient).not.toHaveBeenCalled();
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(subscriptionsApi.createSpaceSubscription).not.toHaveBeenCalled();
   });
 
-  it('renewExpiringSubscriptions should not renew subscriptions expiring in more than 48 hours', async () => {
+  it('should not recreate subscriptions expiring in more than 48 hours', async () => {
     const farFuture = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
     vi.mocked(stateApi.readGoogleChatState).mockResolvedValue({
       channelChatMap: {
@@ -70,74 +64,77 @@ describe('Subscription Renewal Cron', () => {
 
     await renewExpiringSubscriptions(mockConfig);
 
-    expect(authApi.getUserAuthClient).not.toHaveBeenCalled();
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(subscriptionsApi.createSpaceSubscription).not.toHaveBeenCalled();
   });
 
-  it('renewExpiringSubscriptions should renew subscriptions expiring in less than 48 hours', async () => {
+  it('should recreate subscriptions expiring within 48 hours', async () => {
     const nearFuture = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
     vi.mocked(stateApi.readGoogleChatState).mockResolvedValue({
       channelChatMap: {
         space1: {
           chatId: 'chat1',
-          subscriptionId: 'subscriptions/123',
+          subscriptionId: 'subscriptions/old',
           expirationDate: nearFuture,
         },
       },
     } as unknown as GoogleChatState);
-
-    vi.mocked(authApi.getUserAuthClient).mockResolvedValue({
-      getAccessToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
-    } as unknown as OAuth2Client);
-
-    const newExpireTime = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
-    vi.mocked(global.fetch).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ expireTime: newExpireTime }),
-    } as unknown as Response);
+    vi.mocked(subscriptionsApi.createSpaceSubscription).mockResolvedValue({
+      name: 'subscriptions/new',
+      expireTime: new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString(),
+    });
 
     await renewExpiringSubscriptions(mockConfig);
 
-    expect(authApi.getUserAuthClient).toHaveBeenCalledWith(mockConfig);
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://workspaceevents.googleapis.com/v1/subscriptions/123?updateMask=ttl',
-      expect.objectContaining({
-        method: 'PATCH',
-        headers: {
-          Authorization: 'Bearer mock-token',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ ttl: '604800s' }),
-      })
-    );
-
+    expect(subscriptionsApi.createSpaceSubscription).toHaveBeenCalledWith('space1', mockConfig);
     expect(stateApi.updateGoogleChatState).toHaveBeenCalled();
   });
 
-  it('renewExpiringSubscriptions should handle fetch errors gracefully', async () => {
+  it('should recreate already-expired subscriptions', async () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    vi.mocked(stateApi.readGoogleChatState).mockResolvedValue({
+      channelChatMap: {
+        space1: {
+          chatId: 'chat1',
+          subscriptionId: 'subscriptions/old',
+          expirationDate: past,
+        },
+      },
+    } as unknown as GoogleChatState);
+    vi.mocked(subscriptionsApi.createSpaceSubscription).mockResolvedValue({
+      name: 'subscriptions/new',
+      expireTime: new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString(),
+    });
+
+    await renewExpiringSubscriptions(mockConfig);
+
+    expect(subscriptionsApi.createSpaceSubscription).toHaveBeenCalledWith('space1', mockConfig);
+  });
+
+  it('should swallow recreate errors and continue with other entries', async () => {
     const nearFuture = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
     vi.mocked(stateApi.readGoogleChatState).mockResolvedValue({
       channelChatMap: {
         space1: {
           chatId: 'chat1',
-          subscriptionId: 'subscriptions/123',
+          subscriptionId: 'subscriptions/a',
+          expirationDate: nearFuture,
+        },
+        space2: {
+          chatId: 'chat2',
+          subscriptionId: 'subscriptions/b',
           expirationDate: nearFuture,
         },
       },
     } as unknown as GoogleChatState);
-
-    vi.mocked(authApi.getUserAuthClient).mockResolvedValue({
-      getAccessToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
-    } as unknown as OAuth2Client);
-
-    vi.mocked(global.fetch).mockResolvedValue({
-      ok: false,
-      text: vi.fn().mockResolvedValue('Internal Server Error'),
-    } as unknown as Response);
+    vi.mocked(subscriptionsApi.createSpaceSubscription)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({
+        name: 'subscriptions/b-new',
+        expireTime: new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString(),
+      });
 
     await renewExpiringSubscriptions(mockConfig);
 
-    expect(global.fetch).toHaveBeenCalled();
-    expect(stateApi.updateGoogleChatState).not.toHaveBeenCalled();
+    expect(subscriptionsApi.createSpaceSubscription).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/adapter-google-chat/cron.ts
+++ b/src/adapter-google-chat/cron.ts
@@ -1,6 +1,9 @@
 import { readGoogleChatState, updateGoogleChatState } from './state.js';
 import { getUserAuthClient } from './auth.js';
 import type { GoogleChatConfig } from './config.js';
+import { createSpaceSubscription } from './subscriptions.js';
+
+const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
 
 export function startSubscriptionRenewalCron(config: GoogleChatConfig): NodeJS.Timeout {
   // Run every hour
@@ -16,66 +19,106 @@ export function startSubscriptionRenewalCron(config: GoogleChatConfig): NodeJS.T
   );
 }
 
+async function recreateSubscription(
+  externalContextId: string,
+  config: GoogleChatConfig
+): Promise<void> {
+  try {
+    const sub = await createSpaceSubscription(externalContextId, config);
+    await updateGoogleChatState((latestState) => {
+      const currentMap = latestState.channelChatMap || {};
+      return {
+        channelChatMap: {
+          ...currentMap,
+          [externalContextId]: {
+            ...(currentMap[externalContextId] || {}),
+            subscriptionId: sub.name,
+            expirationDate: sub.expireTime,
+          },
+        },
+      };
+    });
+    console.log(`Recreated subscription ${sub.name} for space ${externalContextId}`);
+  } catch (err) {
+    console.error(`Failed to recreate subscription for space ${externalContextId}:`, err);
+  }
+}
+
 export async function renewExpiringSubscriptions(config: GoogleChatConfig): Promise<void> {
   const state = await readGoogleChatState();
   if (!state.channelChatMap) return;
 
   const now = Date.now();
-  const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
 
   for (const [externalContextId, entry] of Object.entries(state.channelChatMap)) {
-    if (entry.subscriptionId && entry.expirationDate) {
-      const expirationTime = new Date(entry.expirationDate).getTime();
-      const timeUntilExpiration = expirationTime - now;
+    if (!entry.subscriptionId || !entry.expirationDate) continue;
 
-      if (timeUntilExpiration < FORTY_EIGHT_HOURS_MS) {
-        console.log(
-          `Renewing expiring subscription ${entry.subscriptionId} for space ${externalContextId}`
-        );
-        try {
-          const userAuthClient = await getUserAuthClient(config);
-          const tokenResponse = await userAuthClient.getAccessToken();
-          const token = tokenResponse.token;
+    const expirationTime = new Date(entry.expirationDate).getTime();
+    const timeUntilExpiration = expirationTime - now;
 
-          if (token) {
-            const res = await fetch(
-              `https://workspaceevents.googleapis.com/v1/${entry.subscriptionId}?updateMask=ttl`,
-              {
-                method: 'PATCH',
-                headers: {
-                  Authorization: `Bearer ${token}`,
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  ttl: '604800s', // 7 days
-                }),
-              }
-            );
+    if (timeUntilExpiration <= 0) {
+      console.log(
+        `Subscription ${entry.subscriptionId} for space ${externalContextId} is past expiration; recreating`
+      );
+      await recreateSubscription(externalContextId, config);
+      continue;
+    }
 
-            if (res.ok) {
-              const subData = (await res.json()) as { expireTime: string };
-              await updateGoogleChatState((latestState) => {
-                const currentMap = latestState.channelChatMap || {};
-                return {
-                  channelChatMap: {
-                    ...currentMap,
-                    [externalContextId]: {
-                      ...(currentMap[externalContextId] || {}),
-                      expirationDate: subData.expireTime,
-                    },
-                  },
-                };
-              });
-              console.log(`Successfully renewed subscription ${entry.subscriptionId}`);
-            } else {
-              const errText = await res.text();
-              console.error(`Failed to renew subscription ${entry.subscriptionId}:`, errText);
-            }
-          }
-        } catch (err) {
-          console.error(`Error renewing subscription ${entry.subscriptionId}:`, err);
+    if (timeUntilExpiration >= FORTY_EIGHT_HOURS_MS) continue;
+
+    console.log(
+      `Renewing expiring subscription ${entry.subscriptionId} for space ${externalContextId}`
+    );
+    try {
+      const userAuthClient = await getUserAuthClient(config);
+      const tokenResponse = await userAuthClient.getAccessToken();
+      const token = tokenResponse.token;
+      if (!token) continue;
+
+      const res = await fetch(
+        `https://workspaceevents.googleapis.com/v1/${entry.subscriptionId}?updateMask=ttl`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            ttl: '604800s', // 7 days
+          }),
         }
+      );
+
+      if (res.ok) {
+        const subData = (await res.json()) as { expireTime: string };
+        await updateGoogleChatState((latestState) => {
+          const currentMap = latestState.channelChatMap || {};
+          return {
+            channelChatMap: {
+              ...currentMap,
+              [externalContextId]: {
+                ...(currentMap[externalContextId] || {}),
+                expirationDate: subData.expireTime,
+              },
+            },
+          };
+        });
+        console.log(`Successfully renewed subscription ${entry.subscriptionId}`);
+      } else if (res.status >= 400 && res.status < 500) {
+        // 4xx means the subscription is gone, unreachable, or can't accept
+        // this renewal (e.g. exceeds max lifetime). Recreate instead.
+        const errText = await res.text();
+        console.warn(
+          `Subscription ${entry.subscriptionId} cannot be renewed (HTTP ${res.status}); recreating: ${errText}`
+        );
+        await recreateSubscription(externalContextId, config);
+      } else {
+        // 5xx: transient — leave it alone and try again next hour.
+        const errText = await res.text();
+        console.error(`Failed to renew subscription ${entry.subscriptionId}:`, errText);
       }
+    } catch (err) {
+      console.error(`Error renewing subscription ${entry.subscriptionId}:`, err);
     }
   }
 }

--- a/src/adapter-google-chat/cron.ts
+++ b/src/adapter-google-chat/cron.ts
@@ -1,5 +1,4 @@
 import { readGoogleChatState, updateGoogleChatState } from './state.js';
-import { getUserAuthClient } from './auth.js';
 import type { GoogleChatConfig } from './config.js';
 import { createSpaceSubscription } from './subscriptions.js';
 
@@ -38,9 +37,9 @@ async function recreateSubscription(
         },
       };
     });
-    console.log(`Recreated subscription ${sub.name} for space ${externalContextId}`);
+    console.log(`Renewed subscription ${sub.name} for space ${externalContextId}`);
   } catch (err) {
-    console.error(`Failed to recreate subscription for space ${externalContextId}:`, err);
+    console.error(`Failed to renew subscription for space ${externalContextId}:`, err);
   }
 }
 
@@ -53,72 +52,12 @@ export async function renewExpiringSubscriptions(config: GoogleChatConfig): Prom
   for (const [externalContextId, entry] of Object.entries(state.channelChatMap)) {
     if (!entry.subscriptionId || !entry.expirationDate) continue;
 
-    const expirationTime = new Date(entry.expirationDate).getTime();
-    const timeUntilExpiration = expirationTime - now;
-
-    if (timeUntilExpiration <= 0) {
-      console.log(
-        `Subscription ${entry.subscriptionId} for space ${externalContextId} is past expiration; recreating`
-      );
-      await recreateSubscription(externalContextId, config);
-      continue;
-    }
-
+    const timeUntilExpiration = new Date(entry.expirationDate).getTime() - now;
     if (timeUntilExpiration >= FORTY_EIGHT_HOURS_MS) continue;
 
-    console.log(
-      `Renewing expiring subscription ${entry.subscriptionId} for space ${externalContextId}`
-    );
-    try {
-      const userAuthClient = await getUserAuthClient(config);
-      const tokenResponse = await userAuthClient.getAccessToken();
-      const token = tokenResponse.token;
-      if (!token) continue;
-
-      const res = await fetch(
-        `https://workspaceevents.googleapis.com/v1/${entry.subscriptionId}?updateMask=ttl`,
-        {
-          method: 'PATCH',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            ttl: '604800s', // 7 days
-          }),
-        }
-      );
-
-      if (res.ok) {
-        const subData = (await res.json()) as { expireTime: string };
-        await updateGoogleChatState((latestState) => {
-          const currentMap = latestState.channelChatMap || {};
-          return {
-            channelChatMap: {
-              ...currentMap,
-              [externalContextId]: {
-                ...(currentMap[externalContextId] || {}),
-                expirationDate: subData.expireTime,
-              },
-            },
-          };
-        });
-        console.log(`Successfully renewed subscription ${entry.subscriptionId}`);
-      } else if (res.status >= 400 && res.status < 500) {
-        // 4xx means the subscription is gone, unreachable, or can't accept
-        // this renewal (e.g. exceeds max lifetime). Recreate instead.
-        const errText = await res.text();
-        console.warn(
-          `Subscription ${entry.subscriptionId} cannot be renewed (HTTP ${res.status}); recreating: ${errText}`
-        );
-        await recreateSubscription(externalContextId, config);
-      } else {
-        // 5xx: transient — leave it alone and try again next hour.
-        const errText = await res.text();
-        console.error(`Failed to renew subscription ${entry.subscriptionId}:`, errText);
-      }
-    } catch (err) {
-      console.error(`Error renewing subscription ${entry.subscriptionId}:`, err);
-    }
+    // PATCH renewal isn't usable for chat-space user-authority subs (Google
+    // caps their lifetime well below 7 days, so any TTL we ask for fails
+    // with "exceeds maximum allowed"). Just recreate when within the window.
+    await recreateSubscription(externalContextId, config);
   }
 }

--- a/src/adapter-google-chat/index.ts
+++ b/src/adapter-google-chat/index.ts
@@ -5,7 +5,7 @@ import { readGoogleChatState } from './state.js';
 import { getTRPCClient, startGoogleChatIngestion } from './client.js';
 import { startDaemonToGoogleChatForwarder } from './forwarder.js';
 import { getUserAuthClient } from './auth.js';
-import { startSubscriptionRenewalCron } from './cron.js';
+import { renewExpiringSubscriptions, startSubscriptionRenewalCron } from './cron.js';
 import type { FilteringConfig } from '../shared/adapters/filtering.js';
 
 export async function main() {
@@ -47,6 +47,12 @@ export async function main() {
   // Start forwarding from daemon to Google Chat API
   startDaemonToGoogleChatForwarder(trpc, config, filteringConfig).catch((error) => {
     console.error('Error in daemon-to-google-chat forwarder:', error);
+  });
+
+  // Sweep subscriptions immediately on startup so we self-heal from anything
+  // that expired or got into a bad state while the adapter was down.
+  renewExpiringSubscriptions(config).catch((err) => {
+    console.error('Error in startup subscription sweep:', err);
   });
 
   // Start background cron for renewing Space Subscriptions

--- a/src/adapter-google-chat/subscriptions.ts
+++ b/src/adapter-google-chat/subscriptions.ts
@@ -3,6 +3,85 @@ import type { GoogleChatConfig } from './config.js';
 import { getAuthClient, getUserAuthClient } from './auth.js';
 import { updateGoogleChatState, type GoogleChatState } from './state.js';
 
+interface OperationResponse {
+  name: string;
+  done?: boolean;
+  response?: { name?: string; expireTime?: string };
+  error?: { code?: number; message?: string };
+}
+
+export interface CreatedSubscription {
+  name: string;
+  expireTime: string;
+}
+
+async function pollOperation(operationName: string, token: string): Promise<OperationResponse> {
+  const delaysMs = [500, 1000, 2000, 3000, 5000, 5000];
+  for (const delay of delaysMs) {
+    const res = await fetch(`https://workspaceevents.googleapis.com/v1/${operationName}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Failed to poll operation ${operationName}: HTTP ${res.status} ${await res.text()}`
+      );
+    }
+    const op = (await res.json()) as OperationResponse;
+    if (op.done) return op;
+    await new Promise((r) => setTimeout(r, delay));
+  }
+  throw new Error(`Operation ${operationName} did not complete within timeout`);
+}
+
+export async function createSpaceSubscription(
+  spaceName: string,
+  config: GoogleChatConfig,
+  startDir: string = process.cwd()
+): Promise<CreatedSubscription> {
+  const userAuthClient = await getUserAuthClient(config, startDir);
+  const tokenResponse = await userAuthClient.getAccessToken();
+  const token = tokenResponse.token;
+  if (!token) throw new Error('No user OAuth access token available');
+
+  const res = await fetch('https://workspaceevents.googleapis.com/v1/subscriptions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      targetResource: `//chat.googleapis.com/${spaceName}`,
+      eventTypes: ['google.workspace.chat.message.v1.created'],
+      authority: 'users/me',
+      payloadOptions: { includeResource: true },
+      notificationEndpoint: {
+        pubsubTopic: `projects/${config.projectId}/topics/${config.topicName}`,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to create subscription for ${spaceName}: HTTP ${res.status} ${await res.text()}`
+    );
+  }
+
+  const operation = (await res.json()) as OperationResponse;
+  const resolved = operation.done ? operation : await pollOperation(operation.name, token);
+
+  if (resolved.error) {
+    throw new Error(`Subscription create operation errored: ${JSON.stringify(resolved.error)}`);
+  }
+  const name = resolved.response?.name;
+  const expireTime = resolved.response?.expireTime;
+  if (!name || !expireTime) {
+    throw new Error(
+      `Subscription create operation completed without expected fields: ${JSON.stringify(resolved)}`
+    );
+  }
+  return { name, expireTime };
+}
+
 export async function handleAddedToSpace(
   spaceName: string,
   externalContextId: string,
@@ -14,50 +93,23 @@ export async function handleAddedToSpace(
 ) {
   if (spaceType !== 'DIRECT_MESSAGE') {
     try {
-      const userAuthClient = await getUserAuthClient(config, startDir);
-      const tokenResponse = await userAuthClient.getAccessToken();
-      const token = tokenResponse.token;
-
-      if (token) {
-        const res = await fetch('https://workspaceevents.googleapis.com/v1/subscriptions', {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            targetResource: `//chat.googleapis.com/${spaceName}`,
-            eventTypes: ['google.workspace.chat.message.v1.created'],
-            payloadOptions: { includeResource: true },
-            notificationEndpoint: {
-              pubsubTopic: `projects/${config.projectId}/topics/${config.topicName}`,
+      const sub = await createSpaceSubscription(spaceName, config, startDir);
+      await updateGoogleChatState((latestState) => {
+        const currentMap = latestState.channelChatMap || {};
+        return {
+          channelChatMap: {
+            ...currentMap,
+            [externalContextId]: {
+              ...(currentMap[externalContextId] || {}),
+              subscriptionId: sub.name,
+              expirationDate: sub.expireTime,
             },
-          }),
-        });
-
-        if (res.ok) {
-          const subData = (await res.json()) as { name: string; expireTime: string };
-          await updateGoogleChatState((latestState) => {
-            const currentMap = latestState.channelChatMap || {};
-            return {
-              channelChatMap: {
-                ...currentMap,
-                [externalContextId]: {
-                  ...(currentMap[externalContextId] || {}),
-                  subscriptionId: subData.name,
-                  expirationDate: subData.expireTime,
-                },
-              },
-            };
-          }, startDir);
-          console.log(`Created subscription ${subData.name} for space ${externalContextId}`);
-        } else {
-          const errText = await res.text();
-          console.error(`Failed to create subscription for space ${externalContextId}:`, errText);
-        }
-      }
+          },
+        };
+      }, startDir);
+      console.log(`Created subscription ${sub.name} for space ${externalContextId}`);
     } catch (err) {
-      console.error('Error setting up subscription on ADDED_TO_SPACE:', err);
+      console.error(`Failed to create subscription for space ${externalContextId}:`, err);
     }
   }
 

--- a/src/adapter-google-chat/subscriptions.ts
+++ b/src/adapter-google-chat/subscriptions.ts
@@ -33,17 +33,8 @@ async function pollOperation(operationName: string, token: string): Promise<Oper
   throw new Error(`Operation ${operationName} did not complete within timeout`);
 }
 
-export async function createSpaceSubscription(
-  spaceName: string,
-  config: GoogleChatConfig,
-  startDir: string = process.cwd()
-): Promise<CreatedSubscription> {
-  const userAuthClient = await getUserAuthClient(config, startDir);
-  const tokenResponse = await userAuthClient.getAccessToken();
-  const token = tokenResponse.token;
-  if (!token) throw new Error('No user OAuth access token available');
-
-  const res = await fetch('https://workspaceevents.googleapis.com/v1/subscriptions', {
+function postCreateSubscription(token: string, spaceName: string, config: GoogleChatConfig) {
+  return fetch('https://workspaceevents.googleapis.com/v1/subscriptions', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -59,6 +50,68 @@ export async function createSpaceSubscription(
       },
     }),
   });
+}
+
+function extractConflictingSubscription(errorBody: string): string | undefined {
+  try {
+    const parsed = JSON.parse(errorBody) as {
+      error?: {
+        details?: Array<{ reason?: string; metadata?: { current_subscription?: string } }>;
+      };
+    };
+    return parsed.error?.details?.find((d) => d.reason === 'SUBSCRIPTION_ALREADY_EXISTS')?.metadata
+      ?.current_subscription;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getBotToken(): Promise<string> {
+  const auth = await getAuthClient();
+  const tokenResponse = await auth.getAccessToken();
+  const token =
+    typeof tokenResponse === 'string' ? tokenResponse : (tokenResponse?.token ?? undefined);
+  if (!token) throw new Error('Failed to obtain bot service-account access token');
+  return token;
+}
+
+export async function createSpaceSubscription(
+  spaceName: string,
+  config: GoogleChatConfig,
+  startDir: string = process.cwd()
+): Promise<CreatedSubscription> {
+  const userAuthClient = await getUserAuthClient(config, startDir);
+  const tokenResponse = await userAuthClient.getAccessToken();
+  const token = tokenResponse.token;
+  if (!token) throw new Error('No user OAuth access token available');
+
+  let res = await postCreateSubscription(token, spaceName, config);
+
+  if (res.status === 409) {
+    // A subscription already exists for this (target, topic, event) tuple.
+    // Common case: a stale legacy app-authority sub created before we set
+    // `authority: 'users/me'`. The user OAuth can't see/delete app-authority
+    // subs, so use the bot's service-account ADC for the cleanup.
+    const errBody = await res.text();
+    const conflictingName = extractConflictingSubscription(errBody);
+    if (!conflictingName) {
+      throw new Error(`Subscription create returned 409 without a conflict name: ${errBody}`);
+    }
+    console.warn(
+      `Conflicting subscription ${conflictingName} exists for ${spaceName}; deleting via bot ADC and retrying`
+    );
+    const botToken = await getBotToken();
+    const delRes = await fetch(`https://workspaceevents.googleapis.com/v1/${conflictingName}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${botToken}` },
+    });
+    if (!delRes.ok) {
+      throw new Error(
+        `Failed to delete conflicting subscription ${conflictingName}: HTTP ${delRes.status} ${await delRes.text()}`
+      );
+    }
+    res = await postCreateSubscription(token, spaceName, config);
+  }
 
   if (!res.ok) {
     throw new Error(


### PR DESCRIPTION
Three bugs were keeping the adapter from receiving non-mention messages in spaces after restart:

- Subscription create was storing the LRO name instead of the underlying subscription name, so every later PATCH (renew) and DELETE targeted an operation, not a subscription, and silently failed.
- No authority was specified on create, so subs defaulted to app authority, leaving them invisible/unmanageable from the user OAuth the adapter uses everywhere else.
- Renewal only ran on the hourly cron tick and only PATCHed; if that PATCH failed for any reason the sub was never recovered.

Now: create sets `authority: 'users/me'`, polls the LRO, and stores the real subscription resource; renewal recreates the sub on any 4xx (covers 400 "exceeds max lifetime", 403, 404) and on past-expiration entries; and the adapter runs an immediate sweep on startup so it self-heals instead of waiting an hour.

Also adds scripts/check-gchat-subscription.mjs for inspecting state vs. the live Workspace Events API.