### PR TITLE
fix(policies): replay approvals on the agent's current session

### DIFF
--- a/e2e/policies/approval-session.test.ts
+++ b/e2e/policies/approval-session.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import {
+  TestEnvironment,
+  type ChatSubscription,
+  type SystemMessage,
+  policyWith,
+} from '../_helpers/test-environment.js';
+
+// When an agent requests a policy and the user /approves it, the approval must
+// be replayed into the agent's *current* session — not a hard-coded 'default'.
+// The current session may have drifted from the one that created the request
+// (e.g. session-timeout fired or the user ran /new).
+describe('Policy approval runs on the agent\'s current session', () => {
+  let env: TestEnvironment;
+  let chat: ChatSubscription | undefined;
+
+  beforeAll(async () => {
+    env = new TestEnvironment('e2e-approval-session');
+    await env.setup();
+    await env.setupSubagentEnv({
+      policies: {
+        'test-cmd': {
+          description: 'A test policy',
+          command: 'echo',
+          args: ['approved-output'],
+        },
+      },
+    });
+  }, 30000);
+
+  afterAll(() => env.teardown(), 30000);
+  afterEach(() => env.disconnectAll());
+
+  it('replays the approval into the session recorded in chatSettings.sessions, not "default"', async () => {
+    const chatId = 'chat-approval-session';
+    await env.addChat(chatId, 'debug-agent');
+
+    // Pin the chat's debug-agent session to a known non-'default' id so the
+    // bug (falling back to 'default') is observable. In production this drift
+    // is what happens after session-timeout or /new.
+    env.writeChatSettings(chatId, {
+      defaultAgent: 'debug-agent',
+      sessions: { 'debug-agent': 'pinned-session-xyz' },
+    });
+
+    chat = await env.connect(chatId);
+
+    // Agent requests the policy. This runs in sessionId='pinned-session-xyz'.
+    await env.sendMessage('clawmini-lite.js request test-cmd', {
+      chat: chatId,
+      agent: 'debug-agent',
+    });
+
+    const policy = await chat.waitForMessage(policyWith());
+    const reqId = policy.requestId;
+
+    await env.sendMessage(`/approve ${reqId}`, { chat: chatId });
+
+    // The second 'policy_approved' system message (displayRole='user') is the
+    // one emitted by the re-triggered agent message pipeline. Its sessionId
+    // reflects the session the approval was actually replayed on.
+    const actorNotif = await chat.waitForMessage(
+      (m): m is SystemMessage =>
+        m.role === 'system' && m.event === 'policy_approved' && m.displayRole === 'user'
+    );
+
+    expect(actorNotif.sessionId).toBe('pinned-session-xyz');
+  }, 30000);
+});

--- a/src/daemon/routers/slash-policies.ts
+++ b/src/daemon/routers/slash-policies.ts
@@ -1,12 +1,24 @@
 import { randomUUID } from 'node:crypto';
 import type { RouterState } from './types.js';
 import { RequestStore } from '../request-store.js';
-import { readPoliciesForPath, getWorkspaceRoot } from '../../shared/workspace.js';
+import { readChatSettings, readPoliciesForPath, getWorkspaceRoot } from '../../shared/workspace.js';
 import { resolveAgentDir } from '../api/router-utils.js';
 import { executeRequest, resolveRequestCwd, truncateLargeOutput } from '../policy-utils.js';
 import { appendMessage } from '../chats.js';
 import type { SystemMessage } from '../../shared/chats.js';
+import type { PolicyRequest } from '../../shared/policies.js';
 import { executeDirectMessage } from '../message.js';
+
+// Resolve which session the approval/rejection should be replayed on. The
+// request may have been created in an earlier session (session-timeout, /new),
+// so we always consult the chat's *current* session for that agent/subagent.
+async function resolveTargetSessionId(chatId: string, req: PolicyRequest): Promise<string> {
+  const chatSettings = await readChatSettings(chatId);
+  if (req.subagentId) {
+    return chatSettings?.subagents?.[req.subagentId]?.sessionId ?? 'default';
+  }
+  return chatSettings?.sessions?.[req.agentId] ?? 'default';
+}
 
 async function loadAndValidateRequest(id: string, state: RouterState) {
   const store = new RequestStore(getWorkspaceRoot());
@@ -72,6 +84,8 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
 
     const agentMessage = `Request ${id} approved.\n\n${wrapInHtml('stdout', stdout)}\n\n${wrapInHtml('stderr', stderr)}\n\nExit Code: ${exitCode}`;
 
+    const targetSessionId = await resolveTargetSessionId(state.chatId, req);
+
     const userNotificationMsg: SystemMessage = {
       id: randomUUID(),
       messageId: state.messageId,
@@ -92,7 +106,8 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
         messageId: randomUUID(),
         message: agentMessage,
         chatId: state.chatId,
-        agentId: state.agentId || 'default',
+        agentId: req.agentId,
+        sessionId: targetSessionId,
         ...(req.subagentId ? { subagentId: req.subagentId } : {}),
         env: state.env || {},
       },
@@ -124,6 +139,8 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
 
     const agentMessage = `Request ${id} rejected. Reason: ${reason}`;
 
+    const targetSessionId = await resolveTargetSessionId(state.chatId, req);
+
     const userNotificationMsg: SystemMessage = {
       id: randomUUID(),
       messageId: state.messageId,
@@ -144,7 +161,8 @@ export async function slashPolicies(state: RouterState): Promise<RouterState> {
         messageId: randomUUID(),
         message: agentMessage,
         chatId: state.chatId,
-        agentId: state.agentId || 'default',
+        agentId: req.agentId,
+        sessionId: targetSessionId,
         ...(req.subagentId ? { subagentId: req.subagentId } : {}),
         env: state.env || {},
       },


### PR DESCRIPTION
`/approve` and `/reject` called `executeDirectMessage` without a sessionId, so the re-triggered agent turn always fell back to 'default'. For subagents (UUID session) or after session-timeout/`/new`, approvals were delivered to the wrong — or nonexistent — session.

Look up the target session from chatSettings at approval time (subagents[subagentId].sessionId for subagent requests, sessions[agentId] otherwise) and pass it through. Also route through req.agentId instead of the approver's state.agentId.