### PR TITLE
fix(policies): auto-create empty policies.json on up

### DIFF
--- a/e2e/policies/auto-create-policies-file.test.ts
+++ b/e2e/policies/auto-create-policies-file.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import { TestEnvironment } from '../_helpers/test-environment.js';
+
+describe('clawmini up auto-creates policies.json', () => {
+  let env: TestEnvironment;
+
+  beforeAll(async () => {
+    env = new TestEnvironment('e2e-auto-create-policies');
+    await env.setup();
+    // Intentionally omit `policies` so no policies.json is pre-written.
+    await env.setupSubagentEnv();
+  }, 30000);
+
+  afterAll(() => env.teardown(), 30000);
+
+  it('creates an empty policies.json during up', () => {
+    const policiesPath = path.resolve(env.e2eDir, '.clawmini/policies.json');
+    expect(fs.existsSync(policiesPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(policiesPath, 'utf8'))).toEqual({ policies: {} });
+  });
+
+  it('exposes the built-in run-host policy even though the user never wrote policies.json', async () => {
+    const { stdout, code } = await env.runLite(['requests', 'list']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('- run-host');
+  }, 30000);
+
+  it('allows --help on run-host via lite without approval', async () => {
+    const { stdout, code } = await env.runLite(['request', 'run-host', '--help']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('--command');
+  }, 30000);
+});

--- a/src/cli/commands/up.ts
+++ b/src/cli/commands/up.ts
@@ -1,8 +1,18 @@
 import { Command } from 'commander';
 import { getDaemonClient } from '../client.js';
-import { getSocketPath } from '../../shared/workspace.js';
+import { getPoliciesPath, getSocketPath } from '../../shared/workspace.js';
 import fs from 'node:fs';
+import path from 'node:path';
 import { installBuiltinPolicies } from '../builtin-policies.js';
+
+// resolvePolicies only exposes built-ins when a policies file exists, so a
+// fresh project needs an empty one for run-host etc. to be visible.
+function ensureDefaultPoliciesFile(): void {
+  const policiesPath = getPoliciesPath();
+  if (fs.existsSync(policiesPath)) return;
+  fs.mkdirSync(path.dirname(policiesPath), { recursive: true });
+  fs.writeFileSync(policiesPath, JSON.stringify({ policies: {} }, null, 2));
+}
 
 export const upCmd = new Command('up')
   .description('Start the local clawmini daemon server')
@@ -12,6 +22,7 @@ export const upCmd = new Command('up')
       const wasRunning = fs.existsSync(socketPath);
 
       await installBuiltinPolicies();
+      ensureDefaultPoliciesFile();
 
       const client = await getDaemonClient({ autoStart: true });
       // Perform a ping to ensure the server is responding


### PR DESCRIPTION
Built-in policies were hidden on fresh projects because resolvePolicies returns null when policies.json is missing. `clawmini up` now writes an empty policies file if none exists so run-host and propose-policy are visible out of the box.

Fixes #190