### PR TITLE
ci: fix release workflow Playwright + Trusted Publishing

### DIFF
--- a/.changeset/fix-release-workflow.md
+++ b/.changeset/fix-release-workflow.md
@@ -1,0 +1,7 @@
+---
+"clawmini": patch
+---
+
+Fix release workflow: install Playwright browsers before running
+validate so the web tests pass on CI, bump Node to 24, and switch npm
+publishing to Trusted Publishing via OIDC instead of an `NPM_TOKEN`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
 
       - name: Validate
         run: npm run validate
@@ -43,6 +46,4 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Install Playwright browsers before validate so web tests pass, bump Node to 24, and switch npm publishing to Trusted Publishing via OIDC.