### PR TITLE
fix(cladding): wrap run-with-network in `sh -c`

### DIFF
--- a/.changeset/cladding-run-with-network-shell.md
+++ b/.changeset/cladding-run-with-network-shell.md
@@ -1,0 +1,15 @@
+---
+"clawmini": patch
+---
+
+Fix `run-with-network` policy in the `cladding` environment template so it
+accepts shell features. The policy used to invoke
+`cladding run-with-scissors <args>` directly, which execs argv inside the
+sandbox — so commands with env-var prefixes (`FOO=1 echo $FOO`),
+multi-statement commands (`echo a && echo b`), pipes, or redirection failed.
+
+The policy now points at a new `run-with-network.mjs` script that takes
+`--command "<shell command>"` (matching the `run-host` interface) and wraps
+the string in `cladding run-with-scissors sh -c …` so the full shell grammar
+is available. The global `run-host` policy already wraps commands in
+`sh -c` and supports these cases.

--- a/templates/environments/cladding/env.json
+++ b/templates/environments/cladding/env.json
@@ -13,10 +13,9 @@
       "allowHelp": false
     },
     "run-with-network": {
-      "description": "Run any command requiring network access. May require first allowlisting domains. Args: <COMMAND>",
-      "allowHelp": false,
-      "command": "cladding",
-      "args": ["run-with-scissors"]
+      "description": "Run a shell command with network access. May require first allowlisting domains. Pass the command via --command, e.g. --command \"npm install\". Supports pipes, &&, env vars, etc.",
+      "allowHelp": true,
+      "command": "./run-with-network.mjs"
     },
     "expose-port": {
       "description": "Expose a port to the network. Use --help for more details.",

--- a/templates/environments/cladding/run-with-network.mjs
+++ b/templates/environments/cladding/run-with-network.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  process.stdout.write(
+    `run-with-network: Run a command with network access via cladding's sandbox.\n` +
+      `\n` +
+      `Usage:\n` +
+      `  run-with-network --command "<shell command>"\n` +
+      `\n` +
+      `The command string is forwarded to \`sh -c\` inside the cladding sandbox,\n` +
+      `so it supports pipes, redirection, &&, ||, environment variables, multiple\n` +
+      `commands, etc.\n` +
+      `\n` +
+      `Examples:\n` +
+      `  run-with-network --command "curl -sSL https://example.com | jq ."\n` +
+      `  run-with-network --command "FOO=1 echo \\$FOO"\n` +
+      `  run-with-network --command 'echo "hello" && echo "world"'\n`
+  );
+  process.exit(0);
+}
+
+const idx = args.indexOf('--command');
+if (idx === -1 || idx + 1 >= args.length) {
+  process.stderr.write(
+    `Error: --command <shell command> is required.\n` +
+      `Usage: run-with-network --command "<shell command>"\n`
+  );
+  process.exit(2);
+}
+const command = args[idx + 1];
+
+// `cladding run-with-scissors` execs its argv directly inside the sandbox, so
+// shell features (env-var prefixes, &&, pipes, multi-line) only work if we
+// hand it an explicit shell. Wrap in `sh -c` so the user's command string is
+// parsed as a script.
+const child = spawn('cladding', ['run-with-scissors', 'sh', '-c', command], {
+  stdio: ['ignore', 'inherit', 'inherit'],
+});
+
+child.on('close', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});
+
+child.on('error', (err) => {
+  process.stderr.write(`Failed to execute command: ${err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
`cladding run-with-scissors` execs argv directly inside the sandbox, so commands with env-var prefixes, &&, pipes, or redirection were failing. Route the policy through a new run-with-network.mjs that takes `--command "<shell>"` and forwards to `cladding run-with-scissors sh -c`.